### PR TITLE
[reboot-cause] Use UTC to ensure consistent sorting

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -254,7 +254,7 @@ def main():
     previous_reboot_cause, additional_reboot_info = determine_reboot_cause()
 
     # Current time
-    reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))
+    reboot_cause_gen_time = str(datetime.datetime.utcnow().strftime('%Y_%m_%d_%H_%M_%S'))
 
     # Save the previous cause info into its history file as json format
     reboot_cause_dict = get_reboot_cause_dict(previous_reboot_cause, additional_reboot_info, reboot_cause_gen_time)

--- a/scripts/procdockerstatsd
+++ b/scripts/procdockerstatsd
@@ -245,7 +245,7 @@ class ProcDockerStats(daemon_base.DaemonBase):
 
         while True:
             self.update_dockerstats_command()
-            datetimeobj = datetime.now()
+            datetimeobj = datetime.utcnow()
             # Adding key to store latest update time.
             self.update_state_db('DOCKER_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
             self.update_processstats_command()

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import pytest
 import json
+import datetime
+import re
 
 from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
@@ -262,3 +264,21 @@ class TestDetermineRebootCause(object):
         # Assert that reboot-cause.txt was created for each DPU
         mock_open.assert_any_call(os.path.join(REBOOT_CAUSE_MODULE_DIR, "dpu0", "reboot-cause.txt"), 'w')
         mock_open.assert_any_call(os.path.join(REBOOT_CAUSE_MODULE_DIR, "dpu1", "reboot-cause.txt"), 'w')
+
+    def test_reboot_cause_gen_time_is_utc(self):
+        # Patch datetime.datetime.utcnow to return a known value
+        class FixedDatetime(datetime.datetime):
+            @classmethod
+            def utcnow(cls):
+                return cls(2024, 7, 1, 12, 34, 56)
+        orig_datetime = determine_reboot_cause.datetime
+        determine_reboot_cause.datetime = FixedDatetime
+
+        try:
+            gen_time = determine_reboot_cause.datetime.utcnow().strftime('%Y_%m_%d_%H_%M_%S')
+            # Should match the fixed UTC time
+            assert gen_time == "2024_07_01_12_34_56"
+            # Optionally, check the format
+            assert re.match(r"\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}", gen_time)
+        finally:
+            determine_reboot_cause.datetime = orig_datetime        

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -199,3 +199,32 @@ class TestProcDockerStatsDaemon(object):
                             
                             # Verify utcnow() was called multiple times as expected
                             assert mock_datetime.utcnow.call_count >= 2        
+
+    def test_run_method_executes_with_utcnow(self):
+        """Test that run method executes and uses datetime.utcnow()"""
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        
+        # Mock all dependencies but allow datetime.utcnow() to run normally
+        with patch.object(pdstatsd, 'update_dockerstats_command'):
+            with patch.object(pdstatsd, 'update_processstats_command'):
+                with patch.object(pdstatsd, 'update_fipsstats_command'):
+                    with patch('time.sleep', side_effect=Exception("Stop after first iteration")):
+                        with patch('os.getuid', return_value=0):  # Mock as root
+                            with patch.object(pdstatsd, 'log_info'):
+                                with patch.object(pdstatsd, 'update_state_db') as mock_update_db:
+                                    # This will actually call run() method
+                                    try:
+                                        pdstatsd.run()
+                                    except Exception as e:
+                                        if "Stop after first iteration" in str(e):
+                                            # Verify that update_state_db was called
+                                            assert mock_update_db.call_count >= 3
+                                            # Verify that timestamps were passed
+                                            for call in mock_update_db.call_args_list:
+                                                args = call[0]
+                                                if len(args) >= 3 and 'lastupdate' in args[1]:
+                                                    timestamp_str = args[2]
+                                                    assert isinstance(timestamp_str, str)
+                                                    assert len(timestamp_str) > 0
+                                        else:
+                                            raise


### PR DESCRIPTION
Previously reboot cause uses local timezone. This could result in the timestamp being in UTC, IDT, or any other timezone depending on the system configuration. When reboot cause history files are sorted, mixing different timezones can lead to incorrect chronological order and cause reboot cause test failure.
Now change the code to use datetime.datetime.utcnow() for reboot_cause_gen_time, ensuring that all timestamps are consistently in UTC.

Details:
Previously reboot-cause history will sort by name, name is using system time, could be UTC or IDT.
2025_07_28_10_48_14  reboot      Mon Jul 28 01:45:45 PM IDT 2025  admin   N/A
Here left side 10_48_14 is UTC time, while right side 01:45:45 is IDT time.
2025_07_28_13_41_44  reboot      Mon Jul 28 01:39:13 PM IDT 2025  admin   N/A
Left and right are both IDT time.
We need to make left side time aligned, so sort index will be always correct.

show reboot-cause history cmd:
```bash
admin@r-bison-06:~$ show reboot-cause history 
Name                 Cause       Time                             User    Comment                                                                                                                                                                                                                                
-------------------  ----------  -------------------------------  ------  ---------                                                                                                                                                                                                                                      
2025_07_28_13_41_44  reboot      Mon Jul 28 01:39:13 PM IDT 2025  admin   N/A                                                                                                                                                                                                                                           
2025_07_28_13_34_54  reboot      Mon Jul 28 01:32:25 PM IDT 2025  admin   N/A                                                                                                                                                                                                                                            
2025_07_28_13_28_13  Watchdog    N/A                              N/A     Unknown                                                                                                                                                                                                              
2025_07_28_13_22_28  reboot      Mon Jul 28 01:19:58 PM IDT 2025  admin   N/A                                                                                                                                                                                                                                  
2025_07_28_13_17_05  reboot      Mon Jul 28 10:15:33 AM UTC 2025  admin   N/A    // Time should be 01:15:33 AM
2025_07_28_10_48_14  reboot      Mon Jul 28 01:45:45 PM IDT 2025  admin   N/A    // This entry should be after 01:39:13 PM IDT                                                                                                                                                                                                                     
2025_07_28_09_57_42  Power Loss  N/A                              N/A     Unknown                                                                                                           
2025_07_28_09_52_04  Power Loss  N/A                              N/A     Unknown                                                                                                                                                                                                                                        
2025_07_28_09_46_15  Power Loss  N/A                              N/A     Unknown                                                                                                          
2025_07_28_09_40_22  Power Loss  N/A                              N/A     Unknown
```

Reboot cause history in test:
```bash
13:53:45 reboot.check_reboot_cause_history        L0532 INFO   | index:  6, reboot cause: Watchdog, reboot cause from DUT: reboot                                                                                                                                                                                        
13:53:45 reboot.check_reboot_cause_history        L0537 ERROR  | The 6 reboot-cause not match. expected_reboot type=Watchdog, actual_reboot_cause=reboot                                                                                                                                                                 
13:53:45 reboot.check_reboot_cause_history        L0541 INFO   | Current reboot_type_history_queue content:                                                                                                                                                                                                              
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=0, reboot_type=power off
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=1, reboot_type=power off
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=2, reboot_type=power off
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=3, reboot_type=power off
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=4, reboot_type=cold
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=5, reboot_type=cold
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=6, reboot_type=watchdog
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=7, reboot_type=cold
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=8, reboot_type=cold
13:53:45 reboot.check_reboot_cause_history        L0543 INFO   |   index=9, reboot_type=cold
```
